### PR TITLE
ci: rename PR build job to `build`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 name: PR Build
 
 jobs:
-  master-build:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Renames the PR build job from `master-build` to `build`.

## Why
Standardizes the PR build status-check name across pivvenit repos so a single org-level ruleset can require a `build` context on the default branch. `build` is the modal pattern across the org (used in 10 repos already).

## ⚠️ Required follow-up after merge
The classic branch protection on `master` currently requires the `master-build` status check. Once this PR is merged, update the protection to require `build` instead — otherwise PRs will be blocked.

## Test plan
- [ ] PR build runs and reports a green `build` check
- [ ] After merge: branch protection updated from `master-build` → `build`